### PR TITLE
Add support for `wasm32-unknown-unknown` target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ futures-util = { version = "0.3.17", default-features = false, features = [
   "std",
   "sink",
 ] }
-tokio-postgres = { version = "0.7.10", optional = true }
-tokio = { version = "1.26", optional = true }
 mysql_async = { version = "0.36.0", optional = true, default-features = false, features = [
   "minimal-rust",
 ] }
@@ -35,6 +33,15 @@ deadpool = { version = "0.12", optional = true, default-features = false, featur
 ] }
 mobc = { version = ">=0.7,<0.10", optional = true }
 scoped-futures = { version = "0.1", features = ["std"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio-postgres = { version = "0.7.10", optional = true }
+tokio = { version = "1.26", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio-postgres = { version = "0.7.10", optional = true, default-features = false, features = ["js"] }
+tokio = { version = "1.26", optional = true, default-features = false }
+wasm-bindgen-futures = { version = "0.4.50" }
 
 [dependencies.diesel]
 version = "~2.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@ pub trait AsyncConnection: SimpleAsyncConnection + Sized + Send {
     /// The argument to this method and the method's behavior varies by backend.
     /// See the documentation for that backend's connection class
     /// for details about what it accepts and how it behaves.
+    #[cfg(not(target_arch = "wasm32"))]
     fn establish(database_url: &str) -> impl Future<Output = ConnectionResult<Self>> + Send;
 
     /// Executes the given function inside of a database transaction

--- a/src/mysql/mod.rs
+++ b/src/mysql/mod.rs
@@ -71,6 +71,7 @@ impl AsyncConnection for AsyncMysqlConnection {
 
     type TransactionManager = AnsiTransactionManager;
 
+    #[cfg(not(target_arch = "wasm32"))]
     async fn establish(database_url: &str) -> diesel::ConnectionResult<Self> {
         let mut instrumentation = DynInstrumentation::default_instrumentation();
         instrumentation.on_connection_event(InstrumentationEvent::start_establish_connection(

--- a/src/pooled_connection/mod.rs
+++ b/src/pooled_connection/mod.rs
@@ -193,6 +193,7 @@ where
     type TransactionManager =
         PoolTransactionManager<<C::Target as AsyncConnection>::TransactionManager>;
 
+    #[cfg(not(target_arch = "wasm32"))]
     async fn establish(_database_url: &str) -> diesel::ConnectionResult<Self> {
         Err(diesel::result::ConnectionError::BadConnection(
             String::from("Cannot directly establish a pooled connection"),

--- a/src/sync_connection_wrapper/mod.rs
+++ b/src/sync_connection_wrapper/mod.rs
@@ -112,6 +112,7 @@ where
     type Backend = <C as Connection>::Backend;
     type TransactionManager = SyncTransactionManagerWrapper<<C as Connection>::TransactionManager>;
 
+    #[cfg(not(target_arch = "wasm32"))]
     async fn establish(database_url: &str) -> ConnectionResult<Self> {
         let database_url = database_url.to_string();
         tokio::task::spawn_blocking(move || C::establish(&database_url))


### PR DESCRIPTION
`tokio-postgres` includes support for targeting `wasm32-unknown-unknown`, and it would be wonderful to have ORM functionality with Diesel in WASM environments.

This PR enables `diesel-async` compilation with the `postgres` feature for the `wasm32-unknown-unknown` target. Please note that I have not explored what is required to support `wasm32-unknown-unknown` for other database or connection types.

I am currently using this within a Cloudflare Workers deployment. (As an aside to anyone exploring, I have not yet been able to configure `diesel-async` to work with Hyperdrive, presumably due to some Postgres feature set that `diesel-async` leverages and that Hyperdrive is not currently supporting. Using `diesel-async` with a direct connection string without Hyperdrive, however, works as expected.)