### PR TITLE
Bump minimal supported `mysql_async` version to `0.37`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Add support for `#[derive(MultiConnection)]`
 * Bump minimal supported Rust version to 1.88.0
+* Bump minimal supported `mysql_async` version to 0.37 (pulls in a patched `lru`, RUSTSEC-2026-0253)
 
 ## [0.9.2] - 2026-06-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ futures-util = { version = "0.3.17", default-features = false, features = [
 ] }
 tokio-postgres = { version = "0.7.10", optional = true }
 tokio = { version = "1.26", optional = true }
-mysql_async = { version = "0.36.0", optional = true, default-features = false, features = [
+mysql_async = { version = "0.37", optional = true, default-features = false, features = [
   "minimal-rust",
 ] }
-mysql_common = { version = "0.35.3", optional = true, default-features = false }
+mysql_common = { version = "0.37", optional = true, default-features = false }
 
 bb8 = { version = "0.9", optional = true }
 async-trait = { version = "0.1.66", optional = true }


### PR DESCRIPTION
The `mysql` feature currently requires `mysql_async 0.36`, whose prepared-statement cache pulls in `lru 0.16`. That version of `lru` is flagged by `RUSTSEC-2026-0253` for a potential use-after-free from missing panic safety in `LruCache::pop`, and the fix only landed in `lru 0.18.2`. No `0.36` release of `mysql_async` permits that, so any project running cargo audit against a `diesel-async` MySQL graph is stuck with the advisory.

This, therefore, bumps the requirement to `mysql_async 0.37`.